### PR TITLE
ci: Add integration and deployment pipelines

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,26 @@
+name: Continous Delivery
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/liblistenbrainz
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install .[build]
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,47 @@
+name: Continous Integration
+
+on: [pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9"] #, "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install
+        run: pip install .[tests]
+      - name: Run tests
+        run: pytest --junitxml=junit/test-results-${{ matrix.python-version }}.xml --cov=pylistenbrainz --cov-report=xml:junit/coverage-${{ matrix.python-version }}.xml
+      - name: Upload 
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-${{ matrix.python-version }}
+          path: junit/*
+
+  report:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/download-artifact@v4
+      - name: Publish Test Reports
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        if: always()
+        with:
+          files: junit-*/test-results-*.xml
+      - name: Create Coverage Report
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: junit-*/coverage-*.xml
+          format: markdown
+          output: both
+      - name: Add coverage PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: code-coverage-results.md

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+junit
 htmlcov/
 .tox/
 .nox/


### PR DESCRIPTION
This adds some automation to the project.

In order to make this work, we would need to setup a Trusted Publisher on Pypi for the project. The documentation is here: https://docs.pypi.org/trusted-publishers/

* Our current pytest version doesn't support python > 3.9, which is why tests are not run there yet. I can file another PR after this is merged
* Linting throws a bunch of things that require fixing, I suggest to handle this in a following PR, too.