### PR TITLE
Add the retry session/wrapper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 [project.optional-dependencies]
 tests = [
   'pytest == 8.3.4',
-  'pytest-cov == 6.0.0'
+  'pytest-cov >= 5.0.0'
 ]
 build = [
   'build',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ dependencies = [
 
 [project.optional-dependencies]
 tests = [
-  'pytest == 5.4.1',
-  'pytest-cov == 2.8.1'
+  'pytest == 8.3.4',
+  'pytest-cov == 6.0.0'
 ]
 build = [
   'build',

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -33,7 +33,7 @@ class ListenBrainzClientTestCase(unittest.TestCase):
     def setUp(self):
         self.client = liblistenbrainz.ListenBrainz()
 
-    @mock.patch('liblistenbrainz.client.requests.get')
+    @mock.patch('liblistenbrainz.client.requests.Session.get')
     def test_get_injects_auth_token_if_available(self, mock_requests_get):
         mock_requests_get.return_value = mock.MagicMock()
         self.client._get('/1/user/iliekcomputers/listens')
@@ -283,7 +283,7 @@ class ListenBrainzClientTestCase(unittest.TestCase):
         with self.assertRaises(errors.ListenBrainzAPIException):
             self.client.submit_single_listen(listen)
 
-    @mock.patch('liblistenbrainz.client.requests.get')
+    @mock.patch('liblistenbrainz.client.requests.Session.get')
     def test_get_api_exceptions(self, mock_requests_get):
         response = mock.MagicMock()
         response.json.return_value = {'code': 401, 'error': 'Unauthorized'}
@@ -295,7 +295,7 @@ class ListenBrainzClientTestCase(unittest.TestCase):
             self.client.get_listens('iliekcomputers')
 
 
-    @mock.patch('liblistenbrainz.client.requests.get')
+    @mock.patch('liblistenbrainz.client.requests.Session.get')
     def test_get_user_recommendation_recordings(self, mock_requests_get):
         mock_requests_get.return_value = mock.MagicMock()
         with self.assertRaises(ValueError):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -55,7 +55,7 @@ class ListenBrainzClientTestCase(unittest.TestCase):
         )
 
 
-    @mock.patch('liblistenbrainz.client.requests.post')
+    @mock.patch('liblistenbrainz.client.requests.Session.post')
     def test_post_injects_auth_token_if_available(self, mock_requests_post):
         mock_requests_post.return_value = mock.MagicMock()
         self.client._post('/1/user/iliekcomputers/listens')
@@ -169,7 +169,7 @@ class ListenBrainzClientTestCase(unittest.TestCase):
         )
         self.assertIsNone(received_listen)
 
-    @mock.patch('liblistenbrainz.client.requests.post')
+    @mock.patch('liblistenbrainz.client.requests.Session.post')
     @mock.patch('liblistenbrainz.client.json.dumps')
     def test_submit_single_listen(self, mock_json_dumps, mock_requests_post):
         ts = int(time.time())


### PR DESCRIPTION
Daily Jams are failing because liblistenbrainz does not have a rate limit exceed retries implemented. This PR adds a retry session wrapper to make it automatically retry with a backoff strategy.